### PR TITLE
precompute nanoTimePrecision

### DIFF
--- a/src/java/org/apache/cassandra/utils/ApproximateTime.java
+++ b/src/java/org/apache/cassandra/utils/ApproximateTime.java
@@ -18,8 +18,6 @@
 
 package org.apache.cassandra.utils;
 
-import java.util.concurrent.CancellationException;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
@@ -29,7 +27,6 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.concurrent.ScheduledExecutors;
 import org.apache.cassandra.config.Config;
-import org.apache.cassandra.config.DatabaseDescriptor;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
@@ -49,6 +46,8 @@ public class ApproximateTime
     private static final int ALMOST_NOW_UPDATE_INTERVAL_MS = Math.max(1, Integer.parseInt(System.getProperty(Config.PROPERTY_PREFIX + "approximate_time_precision_ms", "2")));
     private static final String CONVERSION_UPDATE_INTERVAL_PROPERTY = Config.PROPERTY_PREFIX + "NANOTIMETOMILLIS_TIMESTAMP_UPDATE_INTERVAL";
     private static final long ALMOST_SAME_TIME_UPDATE_INTERVAL_MS = Long.getLong(CONVERSION_UPDATE_INTERVAL_PROPERTY, 10000);
+
+    private static long NANO_TIME_PRECISION = NANOSECONDS.convert(ALMOST_NOW_UPDATE_INTERVAL_MS, MILLISECONDS);
 
     public static class AlmostSameTime
     {
@@ -204,7 +203,7 @@ public class ApproximateTime
 
     public static long nanoTimePrecision()
     {
-        return almostNowPrecision(NANOSECONDS);
+        return NANO_TIME_PRECISION;
     }
 
     /*


### PR DESCRIPTION
Would like to propose a minor improvement to the ApproximateTime.
I ran the ConnectionBurnTest locally (2 endpoints), not sure if I did it right, but this came up in the perf sampler.

Hotspot shot:
<img width="1500" alt="ConnectionBurnTest - hotspot" src="https://user-images.githubusercontent.com/61026/56849252-7ffa5f80-68f2-11e9-9fc5-74835fd51f1d.png">

One of the calltraces shot:
<img width="1492" alt="ConnectionBurnTest - calltree" src="https://user-images.githubusercontent.com/61026/56849253-7ffa5f80-68f2-11e9-9676-92af5a0a2c16.png">

